### PR TITLE
STON-33 allow case insensitive search

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -129,8 +129,9 @@ export async function populateSampleEvictions(configure = false) {
 				filter: { _id: evic._id.$oid },
 				replacement: {
 					tenantName: evic.tenantName,
+					tenantNameLower: evic.tenantName.toLowerCase(),
 					tenantPhone: evic.tenantPhone,
-					tenantEmail: evic.tenantEmail,
+					tenantEmail: evic.tenantEmail.toLowerCase(),
 					user: evic.user.$oid,
 					reason: evic.reason,
 					details: evic.details,

--- a/models/Eviction.js
+++ b/models/Eviction.js
@@ -14,6 +14,10 @@ const evictionsSchema = new mongoose.Schema({
 		required: true,
 		index: true
 	},
+	tenantNameLower: {
+		type: String,
+		index: true
+	},
 	tenantPhone: {
 		type: String,
 		index: true
@@ -30,17 +34,14 @@ const evictionsSchema = new mongoose.Schema({
 	},
 	reason: {
 		type: String,
-		required: true,
-		index: true
+		required: true
 	},
 	details: {
-		type: [evictionDetailsSchema],
-		index: true
+		type: [evictionDetailsSchema]
 	},
 	evictedOn: {
 		type: Date,
-		required: true,
-		index: true
+		required: true
 	},
 	testData: {
 		type: Boolean,
@@ -74,6 +75,7 @@ export async function addEviction(
 ) {
 	let e = await Eviction.create({
 		tenantName: tenantName,
+		tenantNameLower: tenantName.toLowerCase(),
 		tenantPhone: tenantPhone,
 		tenantEmail: tenantEmail,
 		user: userId,
@@ -96,7 +98,7 @@ export async function addConfirmEviction(
 	let e = await ConfirmEviction.create({
 		tenantName: tenantName,
 		tenantPhone: tenantPhone,
-		tenantEmail: tenantEmail,
+		tenantEmail: tenantEmail.toLowerCase(),
 		user: user,
 		reason: reason,
 		evictedOn: evictedOn,
@@ -160,16 +162,18 @@ export function updateEviction(id, ...fields) {
 }
 
 export async function searchForEviction(searchName, searchPhone, searchEmail) {
+	const searchNameLower = searchName.toLowerCase();
+	const searchEmailLower = searchEmail.toLowerCase();
 	const e = await Eviction.aggregate([
 		{
 			'$match': {
 				'$or': [
 					{
-						'tenantName': searchName
+						'tenantNameLower': searchNameLower
 					}, {
 						'tenantPhone': searchPhone
 					}, {
-						'tenantEmail': searchEmail
+						'tenantEmail': searchEmailLower
 					}
 				]
 			}
@@ -179,7 +183,7 @@ export async function searchForEviction(searchName, searchPhone, searchEmail) {
 					'$cond': {
 						'if': {
 							'$eq': [
-								'$tenantName', searchName
+								'$tenantName', searchNameLower
 							]
 						},
 						'then': 1,
@@ -201,7 +205,7 @@ export async function searchForEviction(searchName, searchPhone, searchEmail) {
 					'$cond': {
 						'if': {
 							'$eq': [
-								'$tenantEmail', searchEmail
+								'$tenantEmail', searchEmailLower
 							]
 						},
 						'then': 1,
@@ -217,6 +221,8 @@ export async function searchForEviction(searchName, searchPhone, searchEmail) {
 }
 
 export async function searchEvictionsByUser(searchName, searchPhone, searchEmail, searchUserId) {
+	const searchNameLower = searchName.toLowerCase();
+	const searchEmailLower = searchEmail.toLowerCase();
 	const e = await Eviction.aggregate([
 		{
 			'$match': {
@@ -226,11 +232,11 @@ export async function searchEvictionsByUser(searchName, searchPhone, searchEmail
 					}, {
 						'$or': [
 							{
-								'tenantName': searchName
+								'tenantNameLower': searchNameLower
 							}, {
 								'tenantPhone': searchPhone
 							}, {
-								'tenantEmail': searchEmail
+								'tenantEmail': searchEmailLower
 							}
 						]
 					}
@@ -242,7 +248,7 @@ export async function searchEvictionsByUser(searchName, searchPhone, searchEmail
 					'$cond': {
 						'if': {
 							'$eq': [
-								'$tenantName', searchName
+								'$tenantNameLower', searchNameLower
 							]
 						},
 						'then': 1,
@@ -264,7 +270,7 @@ export async function searchEvictionsByUser(searchName, searchPhone, searchEmail
 					'$cond': {
 						'if': {
 							'$eq': [
-								'$tenantEmail', searchEmail
+								'$tenantEmail', searchEmailLower
 							]
 						},
 						'then': 1,

--- a/routes/evictionRoutes.js
+++ b/routes/evictionRoutes.js
@@ -76,6 +76,7 @@ router.post('/', authenticateToken, async (req, res) => {
 		);
 		res.send(eviction);
 	} catch (err) {
+		console.error(err.message);
 		res.status(500);
 		res.send({ error: 'Internal Server Error ' + err.message });
 	}

--- a/routes/evictionRoutes.js
+++ b/routes/evictionRoutes.js
@@ -24,6 +24,7 @@ router.get('/by-user', authenticateToken, async (req, res) => {
 		const evictions = await getEvictionsByUser(userId);
 		res.send(evictions);
 	} catch (err) {
+		console.error(err.message)
 		res.status(500);
 		res.send({ error: 'Eviction record does not exist' });
 	}
@@ -37,6 +38,7 @@ router.get('/:id', authenticateToken, async (req, res) => {
 		var eviction = await getEvictionByIdLean(evictionId);
 		res.send(eviction);
 	} catch (err) {
+		console.error(err.message)
 		res.status(404);
 		res.send({ error: 'Eviction record does not exist' });
 	}
@@ -50,6 +52,7 @@ router.get('/confirm/:id', authenticateToken, async (req, res) => {
 		var eviction = await getConfirmEvictionByIdLean(evictionId);
 		res.send(eviction);
 	} catch (err) {
+		console.error(err.message)
 		res.status(404);
 		res.send({ error: 'Eviction record does not exist' });
 	}
@@ -66,9 +69,8 @@ router.post('/', authenticateToken, async (req, res) => {
 		const submittedEviction = await getConfirmEvictionById(req.body.id);
 		const eviction = await addEviction(
 			submittedEviction.tenantName,
-			submittedEviction.tenantName.toLowerCase(),
 			submittedEviction.tenantPhone,
-			submittedEviction.tenantEmail.toLowerCase(),
+			submittedEviction.tenantEmail,
 			userid,
 			submittedEviction.reason,
 			submittedEviction.details,
@@ -76,7 +78,7 @@ router.post('/', authenticateToken, async (req, res) => {
 		);
 		res.send(eviction);
 	} catch (err) {
-		console.error(err.message);
+		console.error(err.message)
 		res.status(500);
 		res.send({ error: 'Internal Server Error ' + err.message });
 	}
@@ -122,6 +124,7 @@ router.patch('/:id', authenticateToken, async (req, res) => {
 			res.send(eviction._id);
 		}
 	} catch (err) {
+		console.error(err.message)
 		res.status(404);
 		res.send({ error: 'Record not found. ' + err });
 	}
@@ -142,6 +145,7 @@ router.delete('/:id', authenticateToken, async (req, res, next) => {
 			throw new Error('Only the reporting facility can delete this eviction')
 		}
 	} catch (err) {
+		console.error(err.message)
 		res.status(403);
 		res.send({ error: 'Forbidden. ' + err.message });
 	}

--- a/routes/evictionRoutes.js
+++ b/routes/evictionRoutes.js
@@ -66,8 +66,9 @@ router.post('/', authenticateToken, async (req, res) => {
 		const submittedEviction = await getConfirmEvictionById(req.body.id);
 		const eviction = await addEviction(
 			submittedEviction.tenantName,
+			submittedEviction.tenantName.toLowerCase(),
 			submittedEviction.tenantPhone,
-			submittedEviction.tenantEmail,
+			submittedEviction.tenantEmail.toLowerCase(),
 			userid,
 			submittedEviction.reason,
 			submittedEviction.details,


### PR DESCRIPTION
Azure Cosmos DB does not support the collation indexes used in MongoDB for case-insensitive searches. This PR implements a workaround by adding a field to the Eviction schema which stores the normalized (lowercased) version of tenantName. This is then used when searching against a normalized search string. The display name remains as input by the user.