### PR TITLE
Prevent admin flag from being changed from updateUser calls

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -112,8 +112,9 @@ export async function updateUser(id, fields) {
 	let updateParams = {};
 	//filter out any blank values to avoid accidental data deletion
 	for (const [k, v] of Object.entries(fields)) {
-		// TODO: add handling for invalid params
-		if (k !== '' && v != {}) {
+		// TODO: add handling for invalid/secure fields
+		if ((k !== '' && v != {})
+			&& k !== 'admin') {
 			updateParams[k] = v;
 		}
 	}


### PR DESCRIPTION
Currently, calls to updateUser allow any field to be changed, including security-related ones. This PR adds logic to ignore attempts to change the "admin" field via API calls.